### PR TITLE
Add Python shebang

### DIFF
--- a/tadpole.py
+++ b/tadpole.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from tadpole.main import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
This modification allow us to launch tadpole without putting `python` in front of it.

Before: `python tadpole.py -q cats`
After: `./tadpole.py -q cats`

( the commit was created by "root" because I made it via my awesomely pretty DigitalOcean droplet )